### PR TITLE
Dockerize Symphony oracle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+/test.sh
+/.idea
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+/.git
+/.gitignore
+/.dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+/test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+ARG BUILDPLATFORM="linux/amd64"
+FROM ghcr.io/pfc-developer/heighliner/symphony:v0.4.1 AS symphony
+FROM --platform=${BUILDPLATFORM} python:3-bookworm
+
+WORKDIR /symphony
+COPY --from=symphony /bin/symphonyd /usr/local/bin
+
+COPY . .
+RUN pip install -r ./requirements.txt 
+RUN chmod 755 /symphony/oracle.sh
+ENV VALIDATOR_ADDRESS=symphonyvaloperxxx
+ENV VALIDATOR_ACC_ADDRESS=symphonyxxx
+# - you need to delegate feeder to use this
+ENV FEEDER_ADDRESS=symphonyxxx
+
+ENV FEEDER_SEED=""
+
+#ONLY FOR TELEGRAM NOTIFICATIONS DELETE OTHERWISE
+ENV TELEGRAM_TOKEN=""
+ENV TELEGRAM_CHAT_ID=""
+# MATCH YOUR ACTUAL LCD PORT
+ENV SYMPHONY_LCD=http://localhost:1317 
+# your actual tendermint RPC address%
+ENV TENDERMINT_RPC=tcp://localhost:26657 
+
+ENV PYTHON_ENV=production
+ENV LOG_LEVEL=INFO
+ENV DEBUG=false
+CMD ["/symphony/oracle.sh"]
+#CMD ["/usr/local/bin/python","/symphony/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ ENV FEEDER_ADDRESS=symphonyxxx
 ENV FEEDER_SEED=""
 
 #ONLY FOR TELEGRAM NOTIFICATIONS DELETE OTHERWISE
-ENV TELEGRAM_TOKEN=""
-ENV TELEGRAM_CHAT_ID=""
+ENV TELEGRAM_TOKEN=
+ENV TELEGRAM_CHAT_ID=
 # MATCH YOUR ACTUAL LCD PORT
 ENV SYMPHONY_LCD=http://localhost:1317 
 # your actual tendermint RPC address%
@@ -30,5 +30,7 @@ ENV TENDERMINT_RPC=tcp://localhost:26657
 ENV PYTHON_ENV=production
 ENV LOG_LEVEL=INFO
 ENV DEBUG=false
+
+EXPOSE 19000
 CMD ["/symphony/oracle.sh"]
 #CMD ["/usr/local/bin/python","/symphony/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILDPLATFORM="linux/amd64"
 
 FROM ghcr.io/pfc-developer/heighliner/symphony:v0.4.1 AS symphony
 FROM --platform=${BUILDPLATFORM} python:3-bookworm
-LABEL org.opencontainers.image.description="symphony blockchain price feeder"
+LABEL org.opencontainers.image.description="Symphony blockchain price feeder"
 LABEL org.opencontainers.image.source=https://github.com/cmancrypto/symphony-oracle-voter
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 ARG BUILDPLATFORM="linux/amd64"
+
 FROM ghcr.io/pfc-developer/heighliner/symphony:v0.4.1 AS symphony
 FROM --platform=${BUILDPLATFORM} python:3-bookworm
+LABEL org.opencontainers.image.description="symphony blockchain price feeder"
+LABEL org.opencontainers.image.source=https://github.com/cmancrypto/symphony-oracle-voter
+
 
 WORKDIR /symphony
 COPY --from=symphony /bin/symphonyd /usr/local/bin

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+export V="${1:-latest}"
+docker build --platform=linux/amd64  -t  ghcr.io/pfc-developer/symphony-feeder:${V} .
+docker push  ghcr.io/pfc-developer/symphony-feeder:${V}

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 export V="${1:-latest}"
-docker build --platform=linux/amd64  -t  ghcr.io/pfc-developer/symphony-feeder:${V} .
+docker build --platform=linux/amd64 \
+    -t  ghcr.io/pfc-developer/symphony-feeder:${V} .
 docker push  ghcr.io/pfc-developer/symphony-feeder:${V}

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ logger.debug("logging test")
 
 def main():
     logger.debug("main")
+    telegram("Starting Feeder")
     start_http_server(int(metrics_port))
     logger.debug("starting http server")
     last_prevoted_round = 0

--- a/oracle.sh
+++ b/oracle.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+symphonyd init feeder --chain-id symphony-testnet-4 2>/dev/null
+symphonyd config set client chain-id symphony-testnet-4
+symphonyd config set client keyring-backend test
+symphonyd config set client node "$TENDERMINT_RPC"
+symphonyd query oracle feeder ${VALIDATOR_ADDRESS}
+export KEY_BACKEND=test
+echo $FEEDER_SEED | symphonyd keys add --recover feeder
+export FEEDER_SEED=""
+env > /symphony/.env
+cd /symphony
+/usr/local/bin/python /symphony/main.py


### PR DESCRIPTION
The following creates a Dockerfile and ./build.sh file to allow the feeder to be run in a docker container.
it relies on a previous container to obtain symphonyd. (which is needed by the feeder, as well as required to create the feeder key.

there is also a minor tweak to main.py to 'announce' when the container has been started.
